### PR TITLE
Bump aiohttp from 3.9.3 to 3.12.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 telethon==1.33.1
 aiofiles
 apscheduler
-aiohttp==3.9.3
+aiohttp==3.12.13
 asyncio==3.4.3
 gTTS
 dnspython==2.3.0


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: aiohttp dependency-version: 3.12.13 dependency-type: direct:production update-type: version-update:semver-minor ...